### PR TITLE
SQLite Implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,9 @@ node_modules
 .env
 coverage
 .idea
+
+# SQLite database files
+server/storage/
+*.sqlite
+*.sqlite-wal
+*.sqlite-shm

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "axios": "^1.5.0",
+        "better-sqlite3": "^9.6.0",
         "cors": "^2.8.5",
         "dotenv": "^17.0.1",
         "express": "^5.1.0",
@@ -2908,13 +2909,12 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.10.0.tgz",
-      "integrity": "sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==",
-      "license": "MIT",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
       "dependencies": {
         "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
+        "form-data": "^4.0.4",
         "proxy-from-env": "^1.1.0"
       }
     },
@@ -3061,12 +3061,41 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/batch": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
       "integrity": "sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/better-sqlite3": {
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-9.6.0.tgz",
+      "integrity": "sha512-yR5HATnqeYNVnkaUTf4bOP2dJSnyhP4puJN/QPRyx4YkBEEUxib422n2XzPqDEHjQQqazoYoADdAm5vE15+dAQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      }
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
@@ -3079,6 +3108,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
       }
     },
     "node_modules/body-parser": {
@@ -3195,6 +3242,29 @@
       "license": "Apache-2.0",
       "dependencies": {
         "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/buffer-from": {
@@ -3394,6 +3464,11 @@
         "node": ">= 6"
       }
     },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
+    },
     "node_modules/chrome-trace-event": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
@@ -3564,17 +3639,16 @@
       }
     },
     "node_modules/compression": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/compression/-/compression-1.8.0.tgz",
-      "integrity": "sha512-k6WLKfunuqCYD3t6AsuPGvQWaKwuLLh2/xHNcX4qE+vIfDNXpSqnrhwA7O53R7WVQUnt8dVAIW+YHr7xTgOgGA==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.8.1.tgz",
+      "integrity": "sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "bytes": "3.1.2",
         "compressible": "~2.0.18",
         "debug": "2.6.9",
         "negotiator": "~0.6.4",
-        "on-headers": "~1.0.2",
+        "on-headers": "~1.1.0",
         "safe-buffer": "5.2.1",
         "vary": "~1.1.2"
       },
@@ -3998,6 +4072,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/dedent": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.6.0.tgz",
@@ -4044,6 +4132,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/deep-is": {
@@ -4179,6 +4275,14 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.1.tgz",
+      "integrity": "sha512-ecqj/sy1jcK1uWrwpR67UhYrIFQ+5WlGxth34WquCbamhFA6hkkwiu37o6J5xCHdo1oixJRfVRw+ywV+Hq/0Aw==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/detect-newline": {
@@ -4440,6 +4544,14 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/enhanced-resolve": {
@@ -5383,6 +5495,14 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/expect": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
@@ -5566,6 +5686,11 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
+    },
     "node_modules/filelist": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
@@ -5704,10 +5829,9 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
-      "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
-      "license": "MIT",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -5776,6 +5900,11 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -5936,6 +6065,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="
     },
     "node_modules/glob": {
       "version": "7.2.3",
@@ -6502,6 +6636,25 @@
         "postcss": "^8.1.0"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -6586,6 +6739,11 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
     },
     "node_modules/internal-slot": {
       "version": "1.1.0",
@@ -8753,6 +8911,17 @@
         "node": ">=6"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/min-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -8790,11 +8959,15 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -8835,6 +9008,11 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA=="
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -8867,6 +9045,17 @@
       "dependencies": {
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "3.77.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.77.0.tgz",
+      "integrity": "sha512-DSmt0OEcLoK4i3NuscSbGjOf3bqiDEutejqENSplMSFA/gmB8mkED9G4pKWnPl7MDU4rSHebKPHeitpDfyH0cQ==",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/node-domexception": {
@@ -9156,11 +9345,10 @@
       }
     },
     "node_modules/on-headers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
-      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -9708,6 +9896,31 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -9829,6 +10042,15 @@
         "url": "https://github.com/sponsors/lupomontero"
       }
     },
+    "node_modules/pump": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
+      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -9933,6 +10155,28 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -9969,7 +10213,6 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
@@ -10464,7 +10707,6 @@
       "version": "7.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
       "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -10836,6 +11078,49 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -10995,7 +11280,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
@@ -11265,6 +11549,32 @@
       "integrity": "sha512-Re10+NauLTMCudc7T5WLFLAwDhQ0JWdrMK+9B2M8zR5hRExKmsRDCBA7/aV/pNJFltmBFO5BAMlQFi/vq3nKOg==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
       "engines": {
         "node": ">=6"
       }
@@ -11675,6 +11985,17 @@
       "dev": true,
       "license": "0BSD"
     },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -11916,7 +12237,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/utila": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "dotenv": "^17.0.1",
     "express": "^5.1.0",
     "http-proxy-middleware": "^3.0.5",
+    "better-sqlite3": "^9.6.0",
     "openai": "^4.20.0",
     "papaparse": "^5.5.3",
     "react": "^18.2.0",

--- a/server/db/connection.js
+++ b/server/db/connection.js
@@ -1,0 +1,36 @@
+const path = require('path');
+const fs = require('fs');
+const Database = require('better-sqlite3');
+
+let dbInstance;
+
+function getDb() {
+  if (dbInstance) return dbInstance;
+
+  const storageDir = path.join(__dirname, '..', 'storage');
+  if (!fs.existsSync(storageDir)) {
+    fs.mkdirSync(storageDir, { recursive: true });
+  }
+
+  const dbPath = path.join(storageDir, 'database.sqlite');
+  const db = new Database(dbPath);
+
+  db.pragma('journal_mode = WAL');
+  db.pragma('synchronous = NORMAL');
+
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS decks (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      description TEXT,
+      createdAt TEXT NOT NULL,
+      updatedAt TEXT NOT NULL
+    );
+    CREATE INDEX IF NOT EXISTS idx_decks_name ON decks(name);
+  `);
+
+  dbInstance = db;
+  return dbInstance;
+}
+
+module.exports = { getDb };

--- a/server/db/connection.js
+++ b/server/db/connection.js
@@ -22,12 +22,12 @@ function getDb() {
   db.exec(`
     CREATE TABLE IF NOT EXISTS decks (
       id TEXT PRIMARY KEY,
-      name TEXT NOT NULL,
-      description TEXT,
+      title TEXT NOT NULL,
+      source TEXT,
       createdAt TEXT NOT NULL,
       updatedAt TEXT NOT NULL
     );
-    CREATE INDEX IF NOT EXISTS idx_decks_name ON decks(name);
+    CREATE INDEX IF NOT EXISTS idx_decks_title ON decks(title);
 
     CREATE TABLE IF NOT EXISTS flashcards (
       id TEXT PRIMARY KEY,

--- a/server/db/connection.js
+++ b/server/db/connection.js
@@ -11,14 +11,14 @@ function getDb() {
   if (!fs.existsSync(storageDir)) {
     fs.mkdirSync(storageDir, { recursive: true });
   }
-
   const dbPath = path.join(storageDir, 'database.sqlite');
   const db = new Database(dbPath);
 
   db.pragma('journal_mode = WAL');
   db.pragma('synchronous = NORMAL');
   db.pragma('busy_timeout = 3000');
-
+  db.pragma('foreign_keys = ON');
+  
   db.exec(`
     CREATE TABLE IF NOT EXISTS decks (
       id TEXT PRIMARY KEY,

--- a/server/db/connection.js
+++ b/server/db/connection.js
@@ -47,4 +47,11 @@ function getDb() {
   return dbInstance;
 }
 
-module.exports = { getDb };
+function closeDb() {
+  if (dbInstance) {
+    dbInstance.close();
+    dbInstance = undefined;
+  }
+}
+
+module.exports = { getDb, closeDb };

--- a/server/db/connection.js
+++ b/server/db/connection.js
@@ -17,6 +17,7 @@ function getDb() {
 
   db.pragma('journal_mode = WAL');
   db.pragma('synchronous = NORMAL');
+  db.pragma('busy_timeout = 3000');
 
   db.exec(`
     CREATE TABLE IF NOT EXISTS decks (
@@ -27,6 +28,19 @@ function getDb() {
       updatedAt TEXT NOT NULL
     );
     CREATE INDEX IF NOT EXISTS idx_decks_name ON decks(name);
+
+    CREATE TABLE IF NOT EXISTS flashcards (
+      id TEXT PRIMARY KEY,
+      deckId TEXT NOT NULL,
+      question TEXT NOT NULL,
+      answer TEXT NOT NULL,
+      metadata TEXT,
+      createdAt TEXT NOT NULL,
+      updatedAt TEXT NOT NULL,
+      FOREIGN KEY(deckId) REFERENCES decks(id) ON DELETE CASCADE
+    );
+    CREATE INDEX IF NOT EXISTS idx_flashcards_deck ON flashcards(deckId);
+    CREATE INDEX IF NOT EXISTS idx_flashcards_question ON flashcards(question);
   `);
 
   dbInstance = db;

--- a/server/proxy-server.js
+++ b/server/proxy-server.js
@@ -93,9 +93,36 @@ app.get('/health', (req, res) => {
   res.json({ status: 'ok', mockModeAvailable: true });
 });
 
+const { closeDb } = require('./db/connection');
+
 const PORT = process.env.PROXY_PORT || 3001;
-app.listen(PORT, () => {
+const server = app.listen(PORT, () => {
   console.log(`Proxy server running on http://localhost:${PORT}`);
   console.log(`Forwarding requests from http://localhost:${PORT}/api/v1 to ${process.env.INFERENCE_SERVER_URL || 'http://localhost:1234'}`);
   console.log('Mock mode available: add ?mock=true to URL or set X-Use-Mock header to \'true\'');
+});
+
+const shutdown = (signal) => {
+  console.log(`${new Date().toISOString()} Received ${signal}, initiating graceful shutdown...`);
+  server.close(() => {
+    try {
+      closeDb();
+    } catch (e) {
+      console.error('Error closing database:', e);
+    }
+    console.log('Shutdown complete.');
+    process.exit(0);
+  });
+};
+
+process.on('SIGINT', () => shutdown('SIGINT'));
+process.on('SIGTERM', () => shutdown('SIGTERM'));
+process.on('SIGHUP', () => shutdown('SIGHUP'));
+process.on('exit', (code) => {
+  try {
+    closeDb();
+  } catch (e) {
+    console.error('Error closing database on exit:', e);
+  }
+  console.log(`Process exiting with code ${code}`);
 });

--- a/server/proxy-server.js
+++ b/server/proxy-server.js
@@ -10,6 +10,10 @@ const app = express();
 
 app.use(cors());
 
+// Minimal SQLite-backed storage endpoints
+const storageRouter = require('./routes/storage');
+app.use('/api/storage', storageRouter);
+
 app.use((req, res, next) => {
   console.log(`${new Date().toISOString()} [${req.method}] ${req.url}`);
   next();

--- a/server/routes/storage.js
+++ b/server/routes/storage.js
@@ -50,4 +50,64 @@ router.post('/decks', (req, res) => {
   }
 });
 
+router.get('/decks/:deckId/cards', (req, res) => {
+  const { deckId } = req.params;
+  const q = typeof req.query.q === 'string' ? req.query.q.trim() : '';
+  const limitRaw = typeof req.query.limit === 'string' ? parseInt(req.query.limit, 10) : 50;
+  const offsetRaw = typeof req.query.offset === 'string' ? parseInt(req.query.offset, 10) : 0;
+  const limit = Number.isFinite(limitRaw) && limitRaw > 0 && limitRaw <= 200 ? limitRaw : 50;
+  const offset = Number.isFinite(offsetRaw) && offsetRaw >= 0 ? offsetRaw : 0;
+
+  try {
+    const db = getDb();
+    if (q) {
+      const stmt = db.prepare(
+        'SELECT id, deckId, question, answer, metadata, createdAt, updatedAt FROM flashcards WHERE deckId = ? AND question LIKE ? ORDER BY createdAt DESC LIMIT ? OFFSET ?'
+      );
+      const rows = stmt.all(deckId, `%${q}%`, limit, offset);
+      return res.json(rows);
+    }
+    const stmt = db.prepare(
+      'SELECT id, deckId, question, answer, metadata, createdAt, updatedAt FROM flashcards WHERE deckId = ? ORDER BY createdAt DESC LIMIT ? OFFSET ?'
+    );
+    const rows = stmt.all(deckId, limit, offset);
+    return res.json(rows);
+  } catch (err) {
+    return res.status(500).json({ message: err.message });
+  }
+});
+
+router.post('/decks/:deckId/cards', (req, res) => {
+  const { deckId } = req.params;
+  const payload = req.body && Array.isArray(req.body.cards) ? req.body.cards : [];
+  if (!Array.isArray(payload) || payload.length === 0) {
+    return res.status(400).json({ message: 'cards array is required' });
+  }
+  const now = new Date().toISOString();
+
+  try {
+    const db = getDb();
+    const insert = db.prepare(
+      'INSERT INTO flashcards (id, deckId, question, answer, metadata, createdAt, updatedAt) VALUES (?, ?, ?, ?, ?, ?, ?)'
+    );
+    const insertTx = db.transaction((cards) => {
+      const created = [];
+      for (const c of cards) {
+        if (!c || typeof c.question !== 'string' || typeof c.answer !== 'string') {
+          throw new Error('each card must have string question and answer');
+        }
+        const id = uuidv4();
+        const metadata = c.metadata ? JSON.stringify(c.metadata) : null;
+        insert.run(id, deckId, c.question.trim(), c.answer.trim(), metadata, now, now);
+        created.push({ id, deckId, question: c.question.trim(), answer: c.answer.trim(), metadata, createdAt: now, updatedAt: now });
+      }
+      return created;
+    });
+    const createdCards = insertTx(payload);
+    return res.status(201).json(createdCards);
+  } catch (err) {
+    return res.status(500).json({ message: err.message });
+  }
+});
+
 module.exports = router;

--- a/server/routes/storage.js
+++ b/server/routes/storage.js
@@ -110,4 +110,21 @@ router.post('/decks/:deckId/cards', (req, res) => {
   }
 });
 
+router.delete('/decks/:deckId', (req, res) => {
+  const { deckId } = req.params;
+  try {
+    const db = getDb();
+    const deck = db
+      .prepare('SELECT id FROM decks WHERE id = ?')
+      .get(deckId);
+    if (!deck) {
+      return res.status(404).json({ message: 'deck not found' });
+    }
+    db.prepare('DELETE FROM decks WHERE id = ?').run(deckId);
+    return res.status(204).send();
+  } catch (err) {
+    return res.status(500).json({ message: err.message });
+  }
+});
+
 module.exports = router;

--- a/server/routes/storage.js
+++ b/server/routes/storage.js
@@ -20,7 +20,7 @@ router.get('/decks', (req, res) => {
     const db = getDb();
     const rows = db
       .prepare(
-        'SELECT id, name, description, createdAt, updatedAt FROM decks ORDER BY createdAt DESC'
+        'SELECT id, title, source, createdAt, updatedAt FROM decks ORDER BY createdAt DESC'
       )
       .all();
     return res.json(rows);
@@ -30,19 +30,19 @@ router.get('/decks', (req, res) => {
 });
 
 router.post('/decks', (req, res) => {
-  const { name, description } = req.body || {};
-  if (!name || typeof name !== 'string') {
-    return res.status(400).json({ message: 'name is required (string)' });
+  const { title, source } = req.body || {};
+  if (!title || typeof title !== 'string') {
+    return res.status(400).json({ message: 'title is required (string)' });
   }
   try {
     const db = getDb();
     const now = new Date().toISOString();
     const id = uuidv4();
     db.prepare(
-      'INSERT INTO decks (id, name, description, createdAt, updatedAt) VALUES (?, ?, ?, ?, ?)'
-    ).run(id, name.trim(), description || null, now, now);
+      'INSERT INTO decks (id, title, source, createdAt, updatedAt) VALUES (?, ?, ?, ?, ?)'
+    ).run(id, title.trim(), source || null, now, now);
     const created = db
-      .prepare('SELECT id, name, description, createdAt, updatedAt FROM decks WHERE id = ?')
+      .prepare('SELECT id, title, source, createdAt, updatedAt FROM decks WHERE id = ?')
       .get(id);
     return res.status(201).json(created);
   } catch (err) {

--- a/server/routes/storage.js
+++ b/server/routes/storage.js
@@ -31,7 +31,7 @@ router.get('/decks', (req, res) => {
 
 router.post('/decks', (req, res) => {
   const { title, source } = req.body || {};
-  if (!title || title.trim() === '' || typeof title !== 'string') {
+  if (typeof title !== 'string' || title.trim() === '') {
     return res.status(400).json({ message: 'title is required (string)' });
   }
   try {

--- a/server/routes/storage.js
+++ b/server/routes/storage.js
@@ -31,7 +31,7 @@ router.get('/decks', (req, res) => {
 
 router.post('/decks', (req, res) => {
   const { title, source } = req.body || {};
-  if (!title || typeof title !== 'string') {
+  if (!title || title.trim() === '' || typeof title !== 'string') {
     return res.status(400).json({ message: 'title is required (string)' });
   }
   try {

--- a/server/routes/storage.js
+++ b/server/routes/storage.js
@@ -1,0 +1,53 @@
+const express = require('express');
+const { v4: uuidv4 } = require('uuid');
+const { getDb } = require('../db/connection');
+
+const router = express.Router();
+router.use(express.json());
+
+router.get('/health', (req, res) => {
+  try {
+    const db = getDb();
+    const row = db.prepare('SELECT COUNT(1) as count FROM decks').get();
+    return res.json({ status: 'ok', deckCount: row.count });
+  } catch (err) {
+    return res.status(500).json({ status: 'error', message: err.message });
+  }
+});
+
+router.get('/decks', (req, res) => {
+  try {
+    const db = getDb();
+    const rows = db
+      .prepare(
+        'SELECT id, name, description, createdAt, updatedAt FROM decks ORDER BY createdAt DESC'
+      )
+      .all();
+    return res.json(rows);
+  } catch (err) {
+    return res.status(500).json({ message: err.message });
+  }
+});
+
+router.post('/decks', (req, res) => {
+  const { name, description } = req.body || {};
+  if (!name || typeof name !== 'string') {
+    return res.status(400).json({ message: 'name is required (string)' });
+  }
+  try {
+    const db = getDb();
+    const now = new Date().toISOString();
+    const id = uuidv4();
+    db.prepare(
+      'INSERT INTO decks (id, name, description, createdAt, updatedAt) VALUES (?, ?, ?, ?, ?)'
+    ).run(id, name.trim(), description || null, now, now);
+    const created = db
+      .prepare('SELECT id, name, description, createdAt, updatedAt FROM decks WHERE id = ?')
+      .get(id);
+    return res.status(201).json(created);
+  } catch (err) {
+    return res.status(500).json({ message: err.message });
+  }
+});
+
+module.exports = router;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 
 import FlashcardViewer from './components/FlashcardViewer';
 import InputForm from './components/InputForm';
+import SavedDecksList from './components/SavedDecksList';
 import { FlashcardSet } from './types';
 import './styles/App.css';
 
@@ -19,11 +20,14 @@ const App: React.FC = () => {
 
       <main>
         {flashcardSet === null ? (
-          <InputForm
-            setFlashcardSet={setFlashcardSet}
-            setLoading={setLoading}
-            setError={setError}
-          />
+          <>
+            <SavedDecksList onOpen={(set): void => setFlashcardSet(set)} />
+            <InputForm
+              setFlashcardSet={setFlashcardSet}
+              setLoading={setLoading}
+              setError={setError}
+            />
+          </>
         ) : (
           <FlashcardViewer
             flashcardSet={flashcardSet}

--- a/src/components/FlashcardViewer.tsx
+++ b/src/components/FlashcardViewer.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 
+import { saveSetAsDeck } from '../services/storageService';
 import { FlashcardSet } from '../types';
 import '../styles/FlashcardViewer.css';
 
@@ -12,11 +13,25 @@ const FlashcardViewer: React.FC<FlashcardViewerProps> = ({ flashcardSet, onReset
   const [currentIndex, setCurrentIndex] = useState<number>(0);
   const [flipped, setFlipped] = useState<boolean>(false);
   const [viewMode, setViewMode] = useState<'cards' | 'list'>('cards');
+  const [saving, setSaving] = useState<boolean>(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
 
   const handleNext = (): void => {
     if (currentIndex < flashcardSet.cards.length - 1) {
       setCurrentIndex(currentIndex + 1);
       setFlipped(false);
+    }
+  };
+
+  const handleSave = async (): Promise<void> => {
+    setSaveError(null);
+    setSaving(true);
+    try {
+      await saveSetAsDeck(flashcardSet);
+    } catch (e) {
+      setSaveError('Failed to save deck');
+    } finally {
+      setSaving(false);
     }
   };
 
@@ -181,6 +196,9 @@ const FlashcardViewer: React.FC<FlashcardViewerProps> = ({ flashcardSet, onReset
       )}
 
       <div className="action-buttons">
+        <button type="button" onClick={(): void => { handleSave().catch(() => {}); }} className="export-btn" disabled={saving}>
+          {saving ? 'Saving…' : 'Save Deck'}
+        </button>
         <button type="button" onClick={exportAsCSV} className="export-btn">
           Export as CSV
         </button>
@@ -191,6 +209,7 @@ const FlashcardViewer: React.FC<FlashcardViewerProps> = ({ flashcardSet, onReset
           Create New Flashcards
         </button>
       </div>
+      {saveError !== null && <p style={{ color: 'red' }}>{saveError}</p>}
     </div>
   );
 };

--- a/src/components/SavedDecksList.tsx
+++ b/src/components/SavedDecksList.tsx
@@ -1,0 +1,88 @@
+import React, { useEffect, useState } from 'react';
+
+import { loadDeckAsSet, listDecks, type Deck } from '../services/storageService';
+import type { FlashcardSet } from '../types';
+import '../styles/SavedDecksList.css';
+
+interface SavedDecksListProps {
+  onOpen: (set: FlashcardSet) => void;
+}
+
+const SavedDecksList: React.FC<SavedDecksListProps> = ({ onOpen }) => {
+  const [decks, setDecks] = useState<Deck[]>([]);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchDecks = async (): Promise<void> => {
+    setError(null);
+    setLoading(true);
+    try {
+      const data = await listDecks();
+      setDecks(data);
+    } catch (e) {
+      setError('Failed to load saved decks');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchDecks().catch(() => {});
+  }, []);
+
+  const handleOpen = async (deck: Deck): Promise<void> => {
+    setError(null);
+    setLoading(true);
+    try {
+      const set = await loadDeckAsSet(deck);
+      onOpen(set);
+    } catch (e) {
+      setError('Failed to open deck');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="saved-decks-container" data-component-name="SavedDecksList">
+      <div className="saved-decks-header">
+        <h3 className="saved-decks-title">Saved Decks</h3>
+        <button
+          type="button"
+          className="saved-decks-refresh"
+          onClick={(): void => { fetchDecks().catch(() => {}); }}
+        >
+          Refresh
+        </button>
+      </div>
+
+      {loading === true && <p className="saved-decks-status">Loading...</p>}
+      {error !== null && <p className="saved-decks-error">{error}</p>}
+      {decks.length === 0 && loading === false && error === null && (
+        <p className="saved-decks-status">No saved decks yet</p>
+      )}
+
+      <ul className="saved-decks-list">
+        {decks.map((d) => (
+          <li key={d.id} className="saved-decks-item">
+            <div className="saved-deck-info">
+              <span className="saved-deck-name" title={d.description ?? ''}>{d.name}</span>
+              <span className="saved-deck-meta">
+                {new Date(d.createdAt).toLocaleString()}
+              </span>
+            </div>
+            <button
+              type="button"
+              className="saved-deck-open"
+              onClick={(): void => { handleOpen(d).catch(() => {}); }}
+            >
+              Open
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default SavedDecksList;

--- a/src/components/SavedDecksList.tsx
+++ b/src/components/SavedDecksList.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 
-import { loadDeckAsSet, listDecks, deleteDeck, type Deck } from '../services/storageService';
+import { loadDeckAsSet, listDecks, deleteDeck, updateDeck, type Deck } from '../services/storageService';
 import type { FlashcardSet } from '../types';
 import '../styles/SavedDecksList.css';
 
@@ -36,6 +36,23 @@ const SavedDecksList: React.FC<SavedDecksListProps> = ({ onOpen }) => {
       await fetchDecks();
     } catch (e) {
       setError('Failed to delete deck');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleRename = async (deck: Deck): Promise<void> => {
+    const next = window.prompt('Enter new deck title', deck.title);
+    if (next === null) return;
+    const trimmed = next.trim();
+    if (trimmed.length === 0) return;
+    setError(null);
+    setLoading(true);
+    try {
+      await updateDeck(deck.id, { title: trimmed });
+      await fetchDecks();
+    } catch (e) {
+      setError('Failed to rename deck');
     } finally {
       setLoading(false);
     }
@@ -93,6 +110,13 @@ const SavedDecksList: React.FC<SavedDecksListProps> = ({ onOpen }) => {
                 onClick={(): void => { handleOpen(d).catch(() => {}); }}
               >
                 Open
+              </button>
+              <button
+                type="button"
+                className="saved-decks-refresh"
+                onClick={(): void => { handleRename(d).catch(() => {}); }}
+              >
+                Rename
               </button>
               <button
                 type="button"

--- a/src/components/SavedDecksList.tsx
+++ b/src/components/SavedDecksList.tsx
@@ -27,7 +27,7 @@ const SavedDecksList: React.FC<SavedDecksListProps> = ({ onOpen }) => {
   };
 
   const handleDelete = async (deck: Deck): Promise<void> => {
-    const ok = window.confirm(`Delete deck "${deck.name}"? This cannot be undone.`);
+    const ok = window.confirm(`Delete deck "${deck.title}"? This cannot be undone.`);
     if (!ok) return;
     setError(null);
     setLoading(true);
@@ -81,7 +81,7 @@ const SavedDecksList: React.FC<SavedDecksListProps> = ({ onOpen }) => {
         {decks.map((d) => (
           <li key={d.id} className="saved-decks-item">
             <div className="saved-deck-info">
-              <span className="saved-deck-name" title={d.description ?? ''}>{d.name}</span>
+              <span className="saved-deck-name" title={d.source ?? ''}>{d.title}</span>
               <span className="saved-deck-meta">
                 {new Date(d.createdAt).toLocaleString()}
               </span>

--- a/src/components/SavedDecksList.tsx
+++ b/src/components/SavedDecksList.tsx
@@ -42,14 +42,14 @@ const SavedDecksList: React.FC<SavedDecksListProps> = ({ onOpen }) => {
   };
 
   const handleRename = async (deck: Deck): Promise<void> => {
-    const next = window.prompt('Enter new deck title', deck.title);
-    if (next === null) return;
-    const trimmed = next.trim();
-    if (trimmed.length === 0) return;
+    const newTitle = window.prompt('Enter new deck title', deck.title);
+    if (newTitle === null) return;
+    const trimmedNewTitle = newTitle.trim();
+    if (trimmedNewTitle.length === 0) return;
     setError(null);
     setLoading(true);
     try {
-      await updateDeck(deck.id, { title: trimmed });
+      await updateDeck(deck.id, { title: trimmedNewTitle });
       await fetchDecks();
     } catch (e) {
       setError('Failed to rename deck');

--- a/src/components/SavedDecksList.tsx
+++ b/src/components/SavedDecksList.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 
-import { loadDeckAsSet, listDecks, type Deck } from '../services/storageService';
+import { loadDeckAsSet, listDecks, deleteDeck, type Deck } from '../services/storageService';
 import type { FlashcardSet } from '../types';
 import '../styles/SavedDecksList.css';
 
@@ -21,6 +21,21 @@ const SavedDecksList: React.FC<SavedDecksListProps> = ({ onOpen }) => {
       setDecks(data);
     } catch (e) {
       setError('Failed to load saved decks');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleDelete = async (deck: Deck): Promise<void> => {
+    const ok = window.confirm(`Delete deck "${deck.name}"? This cannot be undone.`);
+    if (!ok) return;
+    setError(null);
+    setLoading(true);
+    try {
+      await deleteDeck(deck.id);
+      await fetchDecks();
+    } catch (e) {
+      setError('Failed to delete deck');
     } finally {
       setLoading(false);
     }
@@ -77,6 +92,13 @@ const SavedDecksList: React.FC<SavedDecksListProps> = ({ onOpen }) => {
               onClick={(): void => { handleOpen(d).catch(() => {}); }}
             >
               Open
+            </button>
+            <button
+              type="button"
+              className="saved-decks-refresh"
+              onClick={(): void => { handleDelete(d).catch(() => {}); }}
+            >
+              Delete
             </button>
           </li>
         ))}

--- a/src/components/SavedDecksList.tsx
+++ b/src/components/SavedDecksList.tsx
@@ -86,20 +86,22 @@ const SavedDecksList: React.FC<SavedDecksListProps> = ({ onOpen }) => {
                 {new Date(d.createdAt).toLocaleString()}
               </span>
             </div>
-            <button
-              type="button"
-              className="saved-deck-open"
-              onClick={(): void => { handleOpen(d).catch(() => {}); }}
-            >
-              Open
-            </button>
-            <button
-              type="button"
-              className="saved-decks-refresh"
-              onClick={(): void => { handleDelete(d).catch(() => {}); }}
-            >
-              Delete
-            </button>
+            <div className="saved-deck-actions">
+              <button
+                type="button"
+                className="saved-deck-open"
+                onClick={(): void => { handleOpen(d).catch(() => {}); }}
+              >
+                Open
+              </button>
+              <button
+                type="button"
+                className="saved-decks-refresh"
+                onClick={(): void => { handleDelete(d).catch(() => {}); }}
+              >
+                Delete
+              </button>
+            </div>
           </li>
         ))}
       </ul>

--- a/src/services/storageService.ts
+++ b/src/services/storageService.ts
@@ -71,3 +71,11 @@ export const saveSetAsDeck = async (set: FlashcardSet): Promise<Deck> => {
 export const deleteDeck = async (deckId: string): Promise<void> => {
   await client.delete(`/decks/${deckId}`);
 };
+
+export const updateDeck = async (
+  deckId: string,
+  patch: { title?: string; source?: string | null },
+): Promise<Deck> => {
+  const res = await client.patch<Deck>(`/decks/${deckId}`, patch);
+  return res.data;
+};

--- a/src/services/storageService.ts
+++ b/src/services/storageService.ts
@@ -1,0 +1,69 @@
+import axios from 'axios';
+
+import { Flashcard, FlashcardSet } from '../types';
+
+export type Deck = {
+  id: string;
+  name: string;
+  description: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+const API_BASE = (process.env.PROXY_BASE_URL !== undefined && process.env.PROXY_BASE_URL !== '')
+  ? process.env.PROXY_BASE_URL
+  : 'http://localhost:3001';
+
+const client = axios.create({ baseURL: `${API_BASE}/api/storage` });
+
+export const listDecks = async (): Promise<Deck[]> => {
+  const res = await client.get<Deck[]>('/decks');
+  return res.data;
+};
+
+export const createDeck = async (
+  name: string,
+  description: string | null,
+): Promise<Deck> => {
+  const res = await client.post<Deck>('/decks', { name, description });
+  return res.data;
+};
+
+export const createCards = async (
+  deckId: string,
+  cards: Flashcard[],
+): Promise<Flashcard[]> => {
+  const payload = { cards: cards.map((c) => ({ question: c.question, answer: c.answer })) };
+  const res = await client.post<Flashcard[]>(`/decks/${deckId}/cards`, payload);
+  return res.data;
+};
+
+export const getDeckCards = async (deckId: string): Promise<Flashcard[]> => {
+  type ApiCard = {
+    id: string;
+    deckId: string;
+    question: string;
+    answer: string;
+    metadata: string | null;
+    createdAt: string;
+    updatedAt: string;
+  };
+  const res = await client.get<ApiCard[]>(`/decks/${deckId}/cards`);
+  return res.data.map((c) => ({ id: c.id, question: c.question, answer: c.answer }));
+};
+
+export const loadDeckAsSet = async (deck: Deck): Promise<FlashcardSet> => {
+  const cards = await getDeckCards(deck.id);
+  return {
+    title: deck.name,
+    source: deck.description ?? 'Saved deck',
+    cards,
+    createdAt: new Date(deck.createdAt),
+  };
+};
+
+export const saveSetAsDeck = async (set: FlashcardSet): Promise<Deck> => {
+  const deck = await createDeck(set.title, set.source);
+  await createCards(deck.id, set.cards);
+  return deck;
+};

--- a/src/services/storageService.ts
+++ b/src/services/storageService.ts
@@ -4,8 +4,8 @@ import { Flashcard, FlashcardSet } from '../types';
 
 export type Deck = {
   id: string;
-  name: string;
-  description: string | null;
+  title: string;
+  source: string | null;
   createdAt: string;
   updatedAt: string;
 };
@@ -22,10 +22,10 @@ export const listDecks = async (): Promise<Deck[]> => {
 };
 
 export const createDeck = async (
-  name: string,
-  description: string | null,
+  title: string,
+  source: string | null,
 ): Promise<Deck> => {
-  const res = await client.post<Deck>('/decks', { name, description });
+  const res = await client.post<Deck>('/decks', { title, source });
   return res.data;
 };
 
@@ -55,8 +55,8 @@ export const getDeckCards = async (deckId: string): Promise<Flashcard[]> => {
 export const loadDeckAsSet = async (deck: Deck): Promise<FlashcardSet> => {
   const cards = await getDeckCards(deck.id);
   return {
-    title: deck.name,
-    source: deck.description ?? 'Saved deck',
+    title: deck.title,
+    source: deck.source ?? 'Saved deck',
     cards,
     createdAt: new Date(deck.createdAt),
   };

--- a/src/services/storageService.ts
+++ b/src/services/storageService.ts
@@ -67,3 +67,7 @@ export const saveSetAsDeck = async (set: FlashcardSet): Promise<Deck> => {
   await createCards(deck.id, set.cards);
   return deck;
 };
+
+export const deleteDeck = async (deckId: string): Promise<void> => {
+  await client.delete(`/decks/${deckId}`);
+};

--- a/src/styles/SavedDecksList.css
+++ b/src/styles/SavedDecksList.css
@@ -1,0 +1,111 @@
+.saved-decks-container {
+  width: 100%;
+  max-width: 800px;
+  background-color: white;
+  border-radius: 8px;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+  padding: 1rem 1.5rem;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+}
+
+.saved-decks-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.75rem;
+}
+
+.saved-decks-title {
+  margin: 0;
+  font-size: 1.2rem;
+  font-weight: 600;
+  color: #4b5563;
+}
+
+.saved-decks-refresh {
+  padding: 0.5rem 0.9rem;
+  background-color: #3498db;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.3s;
+}
+
+.saved-decks-refresh:hover {
+  background-color: #2d86c6;
+}
+
+.saved-decks-status {
+  color: #7f8c8d;
+  margin: 0.5rem 0;
+}
+
+.saved-decks-error {
+  color: #b91c1c;
+  margin: 0.5rem 0;
+}
+
+.saved-decks-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.saved-decks-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem 0;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.saved-deck-info {
+  display: flex;
+  flex-direction: column;
+}
+
+.saved-deck-name {
+  font-weight: 600;
+  color: #2c3e50;
+}
+
+.saved-deck-meta {
+  font-size: 0.85rem;
+  color: #9ca3af;
+}
+
+.saved-deck-open {
+  padding: 0.45rem 0.9rem;
+  background-color: #2ecc71;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.3s;
+}
+
+.saved-deck-open:hover {
+  background-color: #27ae60;
+}
+
+@media (max-width: 768px) {
+  .saved-decks-container {
+    padding: 1rem;
+    width: 95%;
+    margin: 0 auto 1rem;
+  }
+
+  .saved-decks-item {
+    gap: 0.75rem;
+  }
+
+  .saved-decks-open {
+    width: auto;
+  }
+}

--- a/src/styles/SavedDecksList.css
+++ b/src/styles/SavedDecksList.css
@@ -63,6 +63,12 @@
   border-bottom: 1px solid #e5e7eb;
 }
 
+.saved-deck-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
 .saved-deck-info {
   display: flex;
   flex-direction: column;

--- a/tests/components/SavedDecksList.test.tsx
+++ b/tests/components/SavedDecksList.test.tsx
@@ -29,8 +29,8 @@ describe('SavedDecksList', () => {
     const decks: Deck[] = [
       {
         id: 'd3',
-        name: 'Deck To Delete',
-        description: 'desc',
+        title: 'Deck To Delete',
+        source: 'desc',
         createdAt: new Date('2024-03-01T00:00:00Z').toISOString(),
         updatedAt: new Date('2024-03-01T00:00:00Z').toISOString(),
       },
@@ -82,8 +82,8 @@ describe('SavedDecksList', () => {
     const decks: Deck[] = [
       {
         id: 'd1',
-        name: 'Custom Text Flashcards',
-        description: 'Custom text',
+        title: 'Custom Text Flashcards',
+        source: 'Custom text',
         createdAt: new Date('2024-01-01T00:00:00Z').toISOString(),
         updatedAt: new Date('2024-01-01T00:00:00Z').toISOString(),
       },
@@ -123,8 +123,8 @@ describe('SavedDecksList', () => {
     const decksSecond: Deck[] = [
       {
         id: 'd2',
-        name: 'Biology 101',
-        description: 'Intro deck',
+        title: 'Biology 101',
+        source: 'Intro deck',
         createdAt: new Date('2024-02-01T00:00:00Z').toISOString(),
         updatedAt: new Date('2024-02-01T00:00:00Z').toISOString(),
       },

--- a/tests/components/SavedDecksList.test.tsx
+++ b/tests/components/SavedDecksList.test.tsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+
+import SavedDecksList from '../../src/components/SavedDecksList';
+import type { Deck } from '../../src/services/storageService';
+import type { FlashcardSet } from '../../src/types';
+
+jest.mock('../../src/services/storageService', () => {
+  return {
+    __esModule: true,
+    listDecks: jest.fn(),
+    loadDeckAsSet: jest.fn(),
+  };
+});
+
+const { listDecks, loadDeckAsSet } = jest.requireMock('../../src/services/storageService') as {
+  listDecks: jest.Mock;
+  loadDeckAsSet: jest.Mock;
+};
+
+describe('SavedDecksList', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('renders header and empty state', async () => {
+    (listDecks as jest.Mock).mockResolvedValueOnce([] as Deck[]);
+
+    const onOpen = jest.fn();
+    render(<SavedDecksList onOpen={onOpen} />);
+
+    expect(screen.getByText('Saved Decks')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Refresh' })).toBeInTheDocument();
+
+    // Loading appears first
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
+
+    // Then empty state
+    await waitFor(() => {
+      expect(screen.getByText('No saved decks yet')).toBeInTheDocument();
+    });
+  });
+
+  test('renders a list of decks and opens one', async () => {
+    const decks: Deck[] = [
+      {
+        id: 'd1',
+        name: 'Custom Text Flashcards',
+        description: 'Custom text',
+        createdAt: new Date('2024-01-01T00:00:00Z').toISOString(),
+        updatedAt: new Date('2024-01-01T00:00:00Z').toISOString(),
+      },
+    ];
+    (listDecks as jest.Mock).mockResolvedValueOnce(decks);
+
+    const set: FlashcardSet = {
+      title: 'Custom Text Flashcards',
+      source: 'Custom text',
+      createdAt: new Date('2024-01-01T00:00:00Z'),
+      cards: [
+        { id: 'c1', question: 'Q1', answer: 'A1' },
+        { id: 'c2', question: 'Q2', answer: 'A2' },
+      ],
+    };
+    (loadDeckAsSet as jest.Mock).mockResolvedValueOnce(set);
+
+    const onOpen = jest.fn();
+    render(<SavedDecksList onOpen={onOpen} />);
+
+    // Wait for data to load
+    await waitFor(() => {
+      expect(screen.getByText('Custom Text Flashcards')).toBeInTheDocument();
+    });
+
+    const openButton = screen.getByRole('button', { name: 'Open' });
+    fireEvent.click(openButton);
+
+    await waitFor(() => {
+      expect(loadDeckAsSet).toHaveBeenCalledWith(decks[0]);
+      expect(onOpen).toHaveBeenCalledWith(set);
+    });
+  });
+
+  test('refresh button reloads decks', async () => {
+    const decksFirst: Deck[] = [];
+    const decksSecond: Deck[] = [
+      {
+        id: 'd2',
+        name: 'Biology 101',
+        description: 'Intro deck',
+        createdAt: new Date('2024-02-01T00:00:00Z').toISOString(),
+        updatedAt: new Date('2024-02-01T00:00:00Z').toISOString(),
+      },
+    ];
+
+    (listDecks as jest.Mock)
+      .mockResolvedValueOnce(decksFirst)
+      .mockResolvedValueOnce(decksSecond);
+
+    const onOpen = jest.fn();
+    render(<SavedDecksList onOpen={onOpen} />);
+
+    // Initial empty state
+    await waitFor(() => {
+      expect(screen.getByText('No saved decks yet')).toBeInTheDocument();
+    });
+
+    // Click refresh and expect new deck
+    const refreshBtn = screen.getByRole('button', { name: 'Refresh' });
+    fireEvent.click(refreshBtn);
+
+    await waitFor(() => {
+      expect(screen.getByText('Biology 101')).toBeInTheDocument();
+    });
+  });
+});

--- a/tests/services/storageService.test.ts
+++ b/tests/services/storageService.test.ts
@@ -3,9 +3,10 @@ import axios from 'axios';
 const mockGet = jest.fn();
 const mockPost = jest.fn();
 const mockDelete = jest.fn();
+const mockPatch = jest.fn();
 
 jest.mock('axios', () => {
-  const create = jest.fn(() => ({ get: mockGet, post: mockPost, delete: mockDelete }));
+  const create = jest.fn(() => ({ get: mockGet, post: mockPost, delete: mockDelete, patch: mockPatch }));
   return {
     __esModule: true,
     default: { create },
@@ -170,6 +171,24 @@ describe('storageService', () => {
       ],
     });
     expect(deck).toEqual(createdDeck);
+  });
+
+  test('updateDeck calls PATCH /decks/:deckId with payload', async () => {
+    const { updateDeck } = await import('../../src/services/storageService');
+    const deckId = 'deck-xyz';
+    const updated: Deck = {
+      id: deckId,
+      title: 'New Title',
+      source: 'Custom text',
+      createdAt: new Date('2024-05-01T00:00:00Z').toISOString(),
+      updatedAt: new Date('2024-05-02T00:00:00Z').toISOString(),
+    };
+    mockPatch.mockResolvedValueOnce({ data: updated });
+
+    const res = await updateDeck(deckId, { title: 'New Title' });
+
+    expect(mockPatch).toHaveBeenCalledWith(`/decks/${deckId}`, { title: 'New Title' });
+    expect(res).toEqual(updated);
   });
 
   test('deleteDeck calls DELETE /decks/:deckId', async () => {

--- a/tests/services/storageService.test.ts
+++ b/tests/services/storageService.test.ts
@@ -1,0 +1,173 @@
+import axios from 'axios';
+
+const mockGet = jest.fn();
+const mockPost = jest.fn();
+
+jest.mock('axios', () => {
+  const create = jest.fn(() => ({ get: mockGet, post: mockPost }));
+  return {
+    __esModule: true,
+    default: { create },
+  };
+});
+
+import {
+  listDecks,
+  createDeck,
+  createCards,
+  getDeckCards,
+  loadDeckAsSet,
+  saveSetAsDeck,
+  type Deck,
+} from '../../src/services/storageService';
+import type { FlashcardSet } from '../../src/types';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('storageService', () => {
+  test('listDecks calls GET /decks and returns decks', async () => {
+    const decks: Deck[] = [
+      {
+        id: 'd1',
+        name: 'Biology 101',
+        description: 'Intro deck',
+        createdAt: new Date('2024-01-01T00:00:00Z').toISOString(),
+        updatedAt: new Date('2024-01-01T00:00:00Z').toISOString(),
+      },
+    ];
+    mockGet.mockResolvedValueOnce({ data: decks });
+
+    const res = await listDecks();
+
+    expect(mockGet).toHaveBeenCalledWith('/decks');
+    expect(res).toEqual(decks);
+  });
+
+  test('createDeck posts to /decks and returns created deck', async () => {
+    const created: Deck = {
+      id: 'd2',
+      name: 'Custom Text Flashcards',
+      description: 'Custom text',
+      createdAt: new Date('2024-02-01T00:00:00Z').toISOString(),
+      updatedAt: new Date('2024-02-01T00:00:00Z').toISOString(),
+    };
+    mockPost.mockResolvedValueOnce({ data: created });
+
+    const res = await createDeck('Custom Text Flashcards', 'Custom text');
+
+    expect(mockPost).toHaveBeenCalledWith('/decks', {
+      name: 'Custom Text Flashcards',
+      description: 'Custom text',
+    });
+    expect(res).toEqual(created);
+  });
+
+  test('createCards posts normalized cards and returns created', async () => {
+    const deckId = 'd1';
+    const cards = [
+      { id: 'c1', question: 'Q1', answer: 'A1' },
+      { id: 'c2', question: 'Q2', answer: 'A2' },
+    ];
+    const created = [
+      { id: 'c1', question: 'Q1', answer: 'A1' },
+      { id: 'c2', question: 'Q2', answer: 'A2' },
+    ];
+    mockPost.mockResolvedValueOnce({ data: created });
+
+    const res = await createCards(deckId, cards);
+
+    expect(mockPost).toHaveBeenCalledWith(`/decks/${deckId}/cards`, {
+      cards: [
+        { question: 'Q1', answer: 'A1' },
+        { question: 'Q2', answer: 'A2' },
+      ],
+    });
+    expect(res).toEqual(created);
+  });
+
+  test('getDeckCards maps API cards to Flashcard shape', async () => {
+    const deckId = 'd3';
+    const apiCards = [
+      {
+        id: 'x1', deckId, question: 'Q', answer: 'A', metadata: null,
+        createdAt: new Date('2024-03-01T00:00:00Z').toISOString(),
+        updatedAt: new Date('2024-03-01T00:00:00Z').toISOString(),
+      },
+    ];
+    mockGet.mockResolvedValueOnce({ data: apiCards });
+
+    const res = await getDeckCards(deckId);
+
+    expect(mockGet).toHaveBeenCalledWith(`/decks/${deckId}/cards`);
+    expect(res).toEqual([{ id: 'x1', question: 'Q', answer: 'A' }]);
+  });
+
+  test('loadDeckAsSet composes FlashcardSet from deck + cards', async () => {
+    const deck: Deck = {
+      id: 'd4',
+      name: 'Chemistry',
+      description: 'Saved deck',
+      createdAt: new Date('2024-04-01T00:00:00Z').toISOString(),
+      updatedAt: new Date('2024-04-01T00:00:00Z').toISOString(),
+    };
+    const apiCards = [
+      {
+        id: 'x1', deckId: deck.id, question: 'Q', answer: 'A', metadata: null,
+        createdAt: new Date('2024-04-01T00:00:00Z').toISOString(),
+        updatedAt: new Date('2024-04-01T00:00:00Z').toISOString(),
+      },
+    ];
+    mockGet.mockResolvedValueOnce({ data: apiCards });
+
+    const set = await loadDeckAsSet(deck);
+
+    expect(mockGet).toHaveBeenCalledWith(`/decks/${deck.id}/cards`);
+    expect(set).toEqual({
+      title: 'Chemistry',
+      source: 'Saved deck',
+      createdAt: new Date(deck.createdAt),
+      cards: [{ id: 'x1', question: 'Q', answer: 'A' }],
+    });
+  });
+
+  test('saveSetAsDeck creates deck then posts cards', async () => {
+    const set: FlashcardSet = {
+      title: 'Physics',
+      source: 'Custom text',
+      createdAt: new Date('2024-05-01T00:00:00Z'),
+      cards: [
+        { id: 'a1', question: 'Q1', answer: 'A1' },
+        { id: 'a2', question: 'Q2', answer: 'A2' },
+      ],
+    };
+
+    const createdDeck: Deck = {
+      id: 'deck-xyz',
+      name: 'Physics',
+      description: 'Custom text',
+      createdAt: new Date('2024-05-01T00:00:00Z').toISOString(),
+      updatedAt: new Date('2024-05-01T00:00:00Z').toISOString(),
+    };
+
+    // First POST: create deck
+    mockPost.mockResolvedValueOnce({ data: createdDeck });
+    // Second POST: create cards
+    mockPost.mockResolvedValueOnce({ data: set.cards });
+
+    const deck = await saveSetAsDeck(set);
+
+    expect(mockPost).toHaveBeenNthCalledWith(1, '/decks', {
+      name: 'Physics',
+      description: 'Custom text',
+    });
+    expect(mockPost).toHaveBeenNthCalledWith(2, `/decks/${createdDeck.id}/cards`, {
+      cards: [
+        { question: 'Q1', answer: 'A1' },
+        { question: 'Q2', answer: 'A2' },
+      ],
+    });
+    expect(deck).toEqual(createdDeck);
+  });
+});

--- a/tests/services/storageService.test.ts
+++ b/tests/services/storageService.test.ts
@@ -32,8 +32,8 @@ describe('storageService', () => {
     const decks: Deck[] = [
       {
         id: 'd1',
-        name: 'Biology 101',
-        description: 'Intro deck',
+        title: 'Biology 101',
+        source: 'Intro deck',
         createdAt: new Date('2024-01-01T00:00:00Z').toISOString(),
         updatedAt: new Date('2024-01-01T00:00:00Z').toISOString(),
       },
@@ -49,8 +49,8 @@ describe('storageService', () => {
   test('createDeck posts to /decks and returns created deck', async () => {
     const created: Deck = {
       id: 'd2',
-      name: 'Custom Text Flashcards',
-      description: 'Custom text',
+      title: 'Custom Text Flashcards',
+      source: 'Custom text',
       createdAt: new Date('2024-02-01T00:00:00Z').toISOString(),
       updatedAt: new Date('2024-02-01T00:00:00Z').toISOString(),
     };
@@ -59,8 +59,8 @@ describe('storageService', () => {
     const res = await createDeck('Custom Text Flashcards', 'Custom text');
 
     expect(mockPost).toHaveBeenCalledWith('/decks', {
-      name: 'Custom Text Flashcards',
-      description: 'Custom text',
+      title: 'Custom Text Flashcards',
+      source: 'Custom text',
     });
     expect(res).toEqual(created);
   });
@@ -108,8 +108,8 @@ describe('storageService', () => {
   test('loadDeckAsSet composes FlashcardSet from deck + cards', async () => {
     const deck: Deck = {
       id: 'd4',
-      name: 'Chemistry',
-      description: 'Saved deck',
+      title: 'Chemistry',
+      source: 'Saved deck',
       createdAt: new Date('2024-04-01T00:00:00Z').toISOString(),
       updatedAt: new Date('2024-04-01T00:00:00Z').toISOString(),
     };
@@ -146,8 +146,8 @@ describe('storageService', () => {
 
     const createdDeck: Deck = {
       id: 'deck-xyz',
-      name: 'Physics',
-      description: 'Custom text',
+      title: 'Physics',
+      source: 'Custom text',
       createdAt: new Date('2024-05-01T00:00:00Z').toISOString(),
       updatedAt: new Date('2024-05-01T00:00:00Z').toISOString(),
     };
@@ -160,8 +160,8 @@ describe('storageService', () => {
     const deck = await saveSetAsDeck(set);
 
     expect(mockPost).toHaveBeenNthCalledWith(1, '/decks', {
-      name: 'Physics',
-      description: 'Custom text',
+      title: 'Physics',
+      source: 'Custom text',
     });
     expect(mockPost).toHaveBeenNthCalledWith(2, `/decks/${createdDeck.id}/cards`, {
       cards: [

--- a/tests/services/storageService.test.ts
+++ b/tests/services/storageService.test.ts
@@ -2,9 +2,10 @@ import axios from 'axios';
 
 const mockGet = jest.fn();
 const mockPost = jest.fn();
+const mockDelete = jest.fn();
 
 jest.mock('axios', () => {
-  const create = jest.fn(() => ({ get: mockGet, post: mockPost }));
+  const create = jest.fn(() => ({ get: mockGet, post: mockPost, delete: mockDelete }));
   return {
     __esModule: true,
     default: { create },
@@ -169,5 +170,15 @@ describe('storageService', () => {
       ],
     });
     expect(deck).toEqual(createdDeck);
+  });
+
+  test('deleteDeck calls DELETE /decks/:deckId', async () => {
+    const { deleteDeck } = await import('../../src/services/storageService');
+    const deckId = 'deck-xyz';
+    mockDelete.mockResolvedValueOnce({ status: 204 });
+
+    await deleteDeck(deckId);
+
+    expect(mockDelete).toHaveBeenCalledWith(`/decks/${deckId}`);
   });
 });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -33,6 +33,7 @@ module.exports = {
       'process.env.INFERENCE_SERVER_URL': JSON.stringify(process.env.INFERENCE_SERVER_URL || 'https://api.openai.com/v1'),
       'process.env.MODEL_NAME': JSON.stringify(process.env.MODEL_NAME || 'gpt-3.5-turbo-1106'),
       'process.env.LLM_API_KEY': JSON.stringify(process.env.LLM_API_KEY || ''),
+      'process.env.PROXY_BASE_URL': JSON.stringify(process.env.PROXY_BASE_URL || ''),
     }),
   ],
   devServer: {


### PR DESCRIPTION
## Introduction :pencil2:
Implementation of save deck feature. User is able to save any decks generated, and view all previously saved decks.

## Resolution :heavy_check_mark:
- Add connection.js to initialise database
- Add endpoints for SQLite database in storage.js
- Use storageService.ts for calling endpoints from frontend
- Add SavedDecksList for viewing saved decks
- Add tests for SavedDecksList component and storageService

## Screenshots :camera_flash:
<img width="2113" height="1413" alt="image" src="https://github.com/user-attachments/assets/4446dad8-8290-4603-8e66-c9e9c1ad010f" />
<img width="2165" height="1807" alt="image" src="https://github.com/user-attachments/assets/8d148b1c-89ab-43b5-9899-20d7aac9f9c9" />


## Note :warning:
-This PR is only for the SQLite-related work. Will open another PR with work I have done with ChromaDB after this has been reviewed.